### PR TITLE
fix: Auth.ClientCredentials was missing 'oauth/token'

### DIFF
--- a/templates/javascript/auth.mustache
+++ b/templates/javascript/auth.mustache
@@ -151,9 +151,9 @@
             var contentTypes = ['application/x-www-form-urlencoded'];
             var accepts = ['application/json'];
             var returnType = AccessToken;
-
+            
             return this.apiClient.callAuth(
-                'POST',
+                '/oauth/token', 'POST',
                 pathParams, queryParams, headerParams, formParams, postBody,
                 authNames, contentTypes, accepts, returnType
             ); 


### PR DESCRIPTION
parameter